### PR TITLE
Fix for #133

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -14,7 +14,7 @@
     }
   ],
   "syntax": {
-    "version": "v702",
+    "version": "v740sp08",
     "errorNamespace": "^(Z|Y)",
     "globalConstants": [],
     "globalMacros": []

--- a/abaplint.json
+++ b/abaplint.json
@@ -311,10 +311,7 @@
       "enabled": true,
       "exclude": []
     },
-    "use_new": {
-      "enabled": true,
-      "exclude": []
-    },
+    "use_new": false,
     "when_others_last": {
       "enabled": true,
       "exclude": []

--- a/src/backend/zcl_ags_util.clas.abap
+++ b/src/backend/zcl_ags_util.clas.abap
@@ -46,7 +46,7 @@ CLASS ZCL_AGS_UTIL IMPLEMENTATION.
   METHOD get_time.
 
     TRY.
-        rv_time = zcl_abapgit_time=>get( ).
+        rv_time = zcl_abapgit_time=>get_unix( ).
       CATCH zcx_abapgit_exception.
         ASSERT 0 = 1.
     ENDTRY.

--- a/src/backend/zcl_ags_util.clas.testclasses.abap
+++ b/src/backend/zcl_ags_util.clas.testclasses.abap
@@ -6,15 +6,14 @@ CLASS ltcl_get_time DEFINITION FOR TESTING
   FINAL.
 
   PRIVATE SECTION.
-    METHODS: test FOR TESTING.
+    METHODS: get_Time FOR TESTING.
 ENDCLASS.
 
 CLASS ltcl_get_time IMPLEMENTATION.
 
-  METHOD test.
+  METHOD get_Time.
 
     DATA: lv_time TYPE string.
-
 
     lv_time = zcl_ags_util=>get_time( ).
 
@@ -32,12 +31,12 @@ CLASS ltcl_sha1 DEFINITION FOR TESTING
 
   PRIVATE SECTION.
     METHODS:
-      test01 FOR TESTING.
+      get_sha1_for_hello FOR TESTING.
 ENDCLASS.
 
 CLASS ltcl_sha1 IMPLEMENTATION.
 
-  METHOD test01.
+  METHOD get_sha1_for_hello.
 
     DATA: lv_sha1 TYPE zags_sha1.
 


### PR DESCRIPTION
abapGit v.1.92.0 Adjustments: 
- Replaced obsolete Method get_time() through get_unix() of class zcl_abapgit_time
- Renamed some unit test methods