### PR TITLE
Bugfix comitter name

### DIFF
--- a/src/backend/zcl_ags_obj_commit.clas.abap
+++ b/src/backend/zcl_ags_obj_commit.clas.abap
@@ -179,7 +179,7 @@ CLASS ZCL_AGS_OBJ_COMMIT IMPLEMENTATION.
 
     DATA: lv_time TYPE string.
 
-    FIND REGEX '^([\w\*\.\(\)\- ]+) <(.*)> (\d{10}) .\d{4}$' IN iv_field
+    FIND REGEX '^([\w\*\.\,\(\)\- ]+) <(.*)> (\d{10}) .\d{4}$' IN iv_field
       SUBMATCHES
       rs_userfield-name
       rs_userfield-email


### PR DESCRIPTION
The committer can contain commas. When it contains a comma, `abapGitServer`-operations failed.