### PR TITLE
Fix issue #143

### DIFF
--- a/src/backend/zcl_ags_repo.clas.abap
+++ b/src/backend/zcl_ags_repo.clas.abap
@@ -98,7 +98,7 @@ CLASS ZCL_AGS_REPO IMPLEMENTATION.
     DATA: ls_repo TYPE zags_repos.
 
 
-    ASSERT NOT iv_name CA '/\'.
+    ASSERT NOT iv_name CA '/\ '.
     ASSERT NOT iv_name IS INITIAL.
 
 


### PR DESCRIPTION
Though in a rather crude way, this prevents the creation of a repo with a blank space in the name. Prevents later trouble in browsing (see issue #87)
(first ever abapGit commit... fingers crossed!)